### PR TITLE
fix/reduce remove only on reduce.test.js and fix realisation for

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,14 @@ MyArray.prototype.forEach = function(cb, thisArg) {
 MyArray.prototype.reduce = function(cb, initValue) {
   let accumulator = null;
 
+  if (this.length === 0 && initValue !== undefined) {
+    return initValue;
+  }
+
+  if (this.length === 0 && initValue === undefined) {
+    throw new TypeError();
+  }
+
   if (initValue === undefined) {
     accumulator = this[0];
   } else {

--- a/src/index.js
+++ b/src/index.js
@@ -65,8 +65,6 @@ MyArray.prototype.forEach = function(cb, thisArg) {
 };
 
 MyArray.prototype.reduce = function(cb, initValue) {
-  let accumulator = null;
-
   if (this.length === 0 && initValue !== undefined) {
     return initValue;
   }
@@ -75,11 +73,7 @@ MyArray.prototype.reduce = function(cb, initValue) {
     throw new TypeError();
   }
 
-  if (initValue === undefined) {
-    accumulator = this[0];
-  } else {
-    accumulator = cb(initValue, this[0], 0, this);
-  }
+  let accumulator = initValue === undefined ? this[0] : cb(initValue, this[0], 0, this);
 
   for (let i = 1; i < this.length; i++) {
     accumulator = cb(accumulator, this[i], i, this);

--- a/src/tests/reduce.test.js
+++ b/src/tests/reduce.test.js
@@ -58,7 +58,7 @@ describe('tests for method reduce', () => {
     expect(callReduceOnEmptyArray).toThrow(TypeError);
   });
 
-  test.only(`the number of callback function calls should be 
+  test(`the number of callback function calls should be 
   equal to the arr.length with init value and arr.length-1 without`, () => {
     const arr = new MyArray(1, 2, 3, 5);
     const mockCallbackWithInitValue = jest.fn();


### PR DESCRIPTION
If an array is empty but there is an InitialValue as a parameter
If array is empty and InitialValue is specified, callback shouldn't  be called, and methods result should be ItitialValue